### PR TITLE
Fix for chromosome name handling in DbVcfTabix.dbSeek()

### DIFF
--- a/src/main/java/ca/mcgill/mcb/pcingola/snpSift/annotate/DbVcfIndex.java
+++ b/src/main/java/ca/mcgill/mcb/pcingola/snpSift/annotate/DbVcfIndex.java
@@ -15,9 +15,9 @@ public abstract class DbVcfIndex extends DbVcf {
 	}
 
 	/**
-	 * Seek to a new position. Make sure we advance at least one entry
+	 * Seek to a new position.
 	 */
-	protected abstract boolean dbSeek(String chr, int pos);
+	protected abstract boolean dbSeekEntry(VcfEntry vcfEntry);
 
 	/**
 	 * Seek to a new position. Make sure we advance at least one entry
@@ -34,7 +34,7 @@ public abstract class DbVcfIndex extends DbVcf {
 		}
 
 		// Seek
-		if (!dbSeek(vcfEntry.getChromosomeName(), vcfEntry.getStart())) return false;
+		if (!dbSeekEntry(vcfEntry)) return false;
 
 		// Make sure we actually advance at least one entry
 		do {

--- a/src/main/java/ca/mcgill/mcb/pcingola/snpSift/annotate/DbVcfSorted.java
+++ b/src/main/java/ca/mcgill/mcb/pcingola/snpSift/annotate/DbVcfSorted.java
@@ -52,7 +52,11 @@ public class DbVcfSorted extends DbVcfIndex {
 	}
 
 	@Override
-	protected boolean dbSeek(String chr, int pos) {
+	protected boolean dbSeekEntry(VcfEntry vcfEntry) {
+		// Using simple chromosome name
+		String chr = vcfEntry.getChromosomeName();
+		int pos = vcfEntry.getStart();
+
 		long filePosChr = indexDb.getStart(chr);
 		if (filePosChr < 0) return false; // The database file does not have this chromosome
 

--- a/src/main/java/ca/mcgill/mcb/pcingola/snpSift/annotate/DbVcfTabix.java
+++ b/src/main/java/ca/mcgill/mcb/pcingola/snpSift/annotate/DbVcfTabix.java
@@ -18,8 +18,9 @@ public class DbVcfTabix extends DbVcfIndex {
 	}
 
 	@Override
-	protected boolean dbSeek(String chr, int pos) {
-		return vcfDbFile.seek(chr, pos);
+	protected boolean dbSeekEntry(VcfEntry vcfEntry) {
+		// Using original chromosome name
+		return vcfDbFile.seek(vcfEntry.getChromosomeNameOri(), vcfEntry.getStart());
 	}
 
 	/**


### PR DESCRIPTION
Hi! While using your awesome tool I stumbled upon a problem: `snpsift annotate` refused to annotate input VCFs using bgzip-compressed, tabix-indexed VCF databases. It would correctly add INFO headers, but no actual entries were getting annotated. This issue didn't occur with uncompressed databases, though.

After experimenting and inspecting the source, I found the problem: `DbVcfTabix.dbSeek(chr, pos)` receives the simple chromosome name (`vcfEntry.getChromosomeName()`), while it should receive the original name (`vcfEntry.getChromosomeNameOri()`), since it directly traverses the index, which is not aware of the name modifications made by SnpSift. In my case, chromosome names were like this: `chr1`, while TabixReader unsuccessfully tried to fetch chromosome `1` from the database.

To fix the problem, I modified the abstract `DbVcfIndex.dbSeek(str, pos)` to receive the full `vcfEntry`. I had to rename this method to `DbVcfIndex.dbSeekEntry(vcfEntry)`, because it would now conflict with the first `dbSeek` (same syntax). I also made the modifications to `DbVcfSorted.dbSeekEntry()` and `DbVcfTabix.dbSeekEntry()` to extract the appropriate values for the chromosome name (the simple one and the original one, respectively).

My tests indicate that this fixes the handling of compressed and indexed VCF files while not breaking  SnpSift's capability to handle uncompressed, sorted VCFs. Hopefully you could find this useful, and once again thanks a lot for your work on SnpEff and SnpSift!

Yours,
Kirill