### PR TITLE
Fixed incorrect header number for dbNSFP entries

### DIFF
--- a/src/main/java/org/snpsift/SnpSiftCmdDbNsfp.java
+++ b/src/main/java/org/snpsift/SnpSiftCmdDbNsfp.java
@@ -112,7 +112,7 @@ public class SnpSiftCmdDbNsfp extends SnpSift {
 			}
 
 			String infoKey = VcfEntry.vcfInfoKeySafe(DBNSFP_VCF_INFO_PREFIX + key);
-			vcfFile.getVcfHeader().addLine("##INFO=<ID=" + infoKey + ",Number=A,Type=" + type + ",Description=\"" + fieldsToAdd.get(key) + "\">");
+			vcfFile.getVcfHeader().addLine("##INFO=<ID=" + infoKey + ",Number=.,Type=" + type + ",Description=\"" + fieldsToAdd.get(key) + "\">");
 		}
 
 		return false;


### PR DESCRIPTION
This PR changes the header number from `Number=A` to `Number=.` for dbNSFP entries.
This fixes the bug described in issue [36](https://github.com/pcingola/SnpSift/issues/36)