### PR TITLE
pom.xml: change repository url to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,12 @@
     <repository>
       <id>typesafe</id>
       <name>Typesafe Repository</name>
-      <url>http://repo.typesafe.com/typesafe/releases/</url>
+      <url>https://repo.typesafe.com/typesafe/releases/</url>
     </repository>
     <repository>
       <id>hadoop-bam</id>
       <name>Hadoop-BAM</name>
-      <url>http://hadoop-bam.sourceforge.net/maven/</url>
+      <url>https://hadoop-bam.sourceforge.net/maven/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
hadoop-bam and typesafe repo url were using http preventing maven from downloading sources