### PR TITLE
Adding matching for deletions that have longer representations

### DIFF
--- a/src/main/java/org/snpsift/annotate/AnnotateVcfDb.java
+++ b/src/main/java/org/snpsift/annotate/AnnotateVcfDb.java
@@ -372,6 +372,13 @@ public abstract class AnnotateVcfDb {
                 if (var.getReference().equalsIgnoreCase(dbEntry.getReference()) //
                         && var.getAlt().equalsIgnoreCase(dbEntry.getAlt()) //
                 ) return true;
+                // if this is a deletion check if the db entry is a longer synonymus version
+                if (dbEntry.getReference().length() > var.getReference().length()) {
+                    String extraRefStr = dbEntry.getReference().substring(var.getReference().length(), dbEntry.getReference().length());
+                    if (var.getReference().concat(extraRefStr).equalsIgnoreCase(dbEntry.getReference()) //
+                        && var.getAlt().concat(extraRefStr).equalsIgnoreCase(dbEntry.getAlt()) //
+                    ) return true;
+                }
             } else {
                 // No need to use Ref & Alt, it's a match
                 return true;


### PR DESCRIPTION
This patch fixes an issue that comes from the fact that deletions can have different REF but still be the same rsID:

Example from vcf file:

`NC_000003.12    28891307        .       CT      C       306.593 .       AB=0;TYPE=del;technology.ILLUMINA=1 GT:DP:AD:RO:QR:AO:QA:GL 1/1:22:0,14:0:0:14:366:-32.988,-4.21442,0`

Same position from dbSNP:
`NC_000003.12    28891307        rs34247537      CTTTT   C,CT,CTT,CTTT,CTTTTT,CTTTTTT,CTTTTTTT,CTTTTTTTTTTTT     .       .       RS=34247537;dbSNPBuildID=126`

Both represent the same deletion but due to the fact that the dbSNP contains other longer deletions dbSNP has to contain a longer slice of the reference. So will not match using SNPSifts earlier matching algorithm. This patch fixes this issue by appending the extended part of the reference ("TTT" in the example case) to the alt and to the REF then comparing again.

Like this: 
`"CT".concat("TTT") == "CTTTT" && "C".concat("TTT") == "CTTT"`